### PR TITLE
fix: health/status issue and camel health display name in filter picker

### DIFF
--- a/src/components/camel-list-page/CamelAppHealth.tsx
+++ b/src/components/camel-list-page/CamelAppHealth.tsx
@@ -7,6 +7,7 @@ import { UnknownIcon } from '@patternfly/react-icons';
 import { Label } from '@patternfly/react-core';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
+import { HealthStatus, getHealthStatus, getHealthDisplayName } from './camel-health-utils';
 
 type CamelAppHealthProps = {
   health: string;
@@ -14,30 +15,33 @@ type CamelAppHealthProps = {
 
 const CamelAppHealth: React.FC<CamelAppHealthProps> = ({ health }) => {
   const { t } = useTranslation('plugin__camel-dashboard-console');
-  switch (health?.toLowerCase()) {
-    case 'ok':
-    case 'success':
+  const status = getHealthStatus(health);
+  const displayName = getHealthDisplayName(health, t);
+
+  switch (status) {
+    case HealthStatus.HEALTHY:
       return (
         <Label color="green" icon={<GreenCheckCircleIcon />} isCompact>
-          {t('Healthy')}
+          {displayName}
         </Label>
       );
-    case 'warning':
+    case HealthStatus.DEGRADED:
       return (
         <Label color="orange" icon={<YellowExclamationTriangleIcon />} isCompact>
-          {t('Degraded')}
+          {displayName}
         </Label>
       );
-    case 'error':
+    case HealthStatus.CRITICAL:
       return (
         <Label color="red" icon={<RedExclamationCircleIcon />} isCompact>
-          {t('Critical')}
+          {displayName}
         </Label>
       );
+    case HealthStatus.UNKNOWN:
     default:
       return (
         <Label color="grey" icon={<UnknownIcon />} isCompact>
-          {t('Unknown')}
+          {displayName}
         </Label>
       );
   }

--- a/src/components/camel-list-page/camel-health-utils.ts
+++ b/src/components/camel-list-page/camel-health-utils.ts
@@ -1,0 +1,34 @@
+export enum HealthStatus {
+  HEALTHY = 'Healthy',
+  DEGRADED = 'Degraded',
+  CRITICAL = 'Critical',
+  UNKNOWN = 'Unknown',
+}
+
+export function getHealthDisplayName(health: string, t: (key: string) => string): string {
+  switch (health?.toLowerCase()) {
+    case 'ok':
+    case 'success':
+      return t('Healthy');
+    case 'warning':
+      return t('Degraded');
+    case 'error':
+      return t('Critical');
+    default:
+      return t('Unknown');
+  }
+}
+
+export function getHealthStatus(health: string): HealthStatus {
+  switch (health?.toLowerCase()) {
+    case 'ok':
+    case 'success':
+      return HealthStatus.HEALTHY;
+    case 'warning':
+      return HealthStatus.DEGRADED;
+    case 'error':
+      return HealthStatus.CRITICAL;
+    default:
+      return HealthStatus.UNKNOWN;
+  }
+}


### PR DESCRIPTION
Closes #115 

Prefix filter IDs with their type:
  - `{ id: "camel-health-Error", title: "Critical" }`
  - `{ id: "status-Error", title: "Error" }`

And use the correct translation in the picker