### PR TITLE
Adds hawtio console plugin as a dependency to the helm install

### DIFF
--- a/charts/camel-dashboard-console/Chart.yaml
+++ b/charts/camel-dashboard-console/Chart.yaml
@@ -11,3 +11,9 @@ keywords:
   - react
 sources:
   - https://github.com/camel-tooling/camel-dashboard-console.git
+dependencies:
+  - name: hawtio-online-console-plugin
+    version: 0.6.1
+    repository: "https://hawtio.github.io/hawtio-charts"
+    # If the user sets 'hawtio.enabled' to false, the sub-chart is skipped.
+    condition: hawtio.enabled

--- a/charts/camel-dashboard-console/values.yaml
+++ b/charts/camel-dashboard-console/values.yaml
@@ -72,3 +72,8 @@ camelAppRbac:
 #        name: camel-developer
 #        namespace: openshift-monitoring
 
+hawtio:
+  # Install Hawtio automatically
+  # If Hawtio is already installed or not required
+  # then change this to false
+  enabled: true


### PR DESCRIPTION
* Chart.yaml
  * Specifies the hawtio-online-console-plugin as a dependency of the camel-dashboard with a condition making the install optional
  * To disable: helm install ... --set hawtio.enabled=false

To Build
* Use `helm dependency update camel-dashboard-console` to download the hawtio version. This is required or `helm package` will fail with error.
* Use `helm package camel-dashboard-console` to build the new version of the helm install package.

When `helm install...` is executed (and hawtio.enabled is true) then both plugins are installed into the same namespace. Usefully, on `helm uninstall ...` of the camel-dashboard, hawtio is also removed too.