### PR TITLE
Removes the patch-console-job and pod after successful completion

### DIFF
--- a/charts/camel-dashboard-console/templates/patch-consoles-job.yaml
+++ b/charts/camel-dashboard-console/templates/patch-consoles-job.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "camel-dashboard-console.labels" . | nindent 4 }}
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
   parallelism: 1
   template:


### PR DESCRIPTION
* When the patch-console job is executed, it creates both the job and a pod. When completed, both the job and pod hang around with a status of "completed". By adding this extra annotation, both are removed upon a successful completion.